### PR TITLE
Example UID entrypoint to enable restricted SCC

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+# Patch /etc/passwd file with the current user info.
+# The current user's entry must be correctly defined in this file in order for
+# the `ssh` command to work within the created container.
+
+if ! whoami &>/dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-runner}:x:$(id -u):$(id -g):${USER_NAME:-runner} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec "${OPERATOR:-/usr/local/bin/ansible-operator}"

--- a/bin/user_setup
+++ b/bin/user_setup
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -x
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+mkdir -p ${HOME}
+chown ${USER_UID}:0 ${HOME}
+chmod ug+rwx ${HOME}
+
+# runtime user will need to be able to self-insert in /etc/passwd
+chmod g+rw /etc/passwd
+
+# no need for this script to remain in the image after running
+rm $0

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,8 +1,5 @@
 FROM quay.io/shawn_hurley/ansible-operator
 
-COPY busybox/ /opt/ansible/roles/busybox/
-COPY playbook.yaml /opt/ansible/playbook.yaml
-COPY config.yaml /opt/ansible/config.yaml
-
-RUN adduser ansible-operator
-USER ansible-operator
+COPY busybox/ ${HOME}/roles/busybox/
+COPY playbook.yaml ${HOME}/playbook.yaml
+COPY config.yaml ${HOME}/config.yaml

--- a/example/deploy/operator.yaml
+++ b/example/deploy/operator.yaml
@@ -15,8 +15,6 @@ spec:
       containers:
         - name: ansible-operator
           image: docker.io/shurley/busybox-ansible-operator-test
-          command:
-          - ansible-operator
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/tmp/build/Dockerfile
+++ b/tmp/build/Dockerfile
@@ -8,5 +8,17 @@ RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
     && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
 
+ENV OPERATOR=/usr/local/bin/ansible-operator \
+    USER_UID=1001 \
+    USER_NAME=runner \
+    HOME=/opt/ansible
+
 # install operator binary
-ADD tmp/_output/bin/ansible-operator /usr/local/bin/ansible-operator
+ADD tmp/_output/bin/ansible-operator ${OPERATOR}
+
+COPY bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}


### PR DESCRIPTION
When running in OpenShift under the standard `restricted` SCC the uid is random, so it's necessary to grant access to the `anyuid` SCC for the current operator to work.

This PR adds a custom entrypoint to the example operator image that patches `/etc/passwd` at runtime with the container uid so that ansible (ssh) works with the default (restricted) SCC. This approach is used by other images (e.g. openshift-ansible).

This type support should probably eventually be built in the base image so that this customization is not needed. Right now ansible-runner seems to have some [partial](https://github.com/ansible/ansible-runner/blob/a28182bc0450b319ac6360b19181b4ee27eed19b/Dockerfile#L23) [support](https://github.com/ansible/ansible-runner/blob/a28182bc0450b319ac6360b19181b4ee27eed19b/utils/entrypoint.sh) for this but it does not work yet.
