### PR TITLE
propagates a python virtual environment from ansible-runner to ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,8 @@ cp -a example/busybox /opt/ansible/roles/
 ```
 
 Ensure that ansible and ansible-runner (>= 1.0.5) are installed. Consider using
-a python virtualenv. In that case, add these lines to your playbook:
-
-```
-  vars:
-    ansible_python_interpreter: /path/to/your/virtualenv/bin/python
-```
+a python virtualenv. If you run the operator in a shell with an active virtualenv,
+that will be propagated to ansible-runner and ansible.
 
 ### Run
 

--- a/pkg/runner/internal/inputdir/inputdir.go
+++ b/pkg/runner/internal/inputdir/inputdir.go
@@ -2,6 +2,7 @@ package inputdir
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -65,7 +66,15 @@ func (i *InputDir) Write() error {
 	if err != nil {
 		return err
 	}
-	err = i.addFile("inventory/hosts", []byte("localhost ansible_connection=local"))
+
+	// If ansible-runner is running in a python virtual environment, propagate
+	// that to ansible.
+	venv := os.Getenv("VIRTUAL_ENV")
+	hosts := "localhost ansible_connection=local"
+	if venv != "" {
+		hosts = fmt.Sprintf("%s ansible_python_interpreter=%s", hosts, filepath.Join(venv, "bin/python"))
+	}
+	err = i.addFile("inventory/hosts", []byte(hosts))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If the environment variable VIRTUAL_ENV is set for the operator, it will
use it to construct a python interpreter path for ansible.