### PR TITLE
Moves ResourceStatus and related code to the handler package.

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -64,15 +64,15 @@ func defaultHandle(ctx context.Context, event sdk.Event, run runner.Runner) erro
 	}
 	statusMap, ok := u.Object["status"].(map[string]interface{})
 	if !ok {
-		u.Object["status"] = runner.ResourceStatus{
-			Status: runner.NewStatusFromStatusJobEvent(statusEvent),
+		u.Object["status"] = ResourceStatus{
+			Status: NewStatusFromStatusJobEvent(statusEvent),
 		}
 		sdk.Update(u)
 		logrus.Infof("adding status for the first time")
 		return nil
 	}
 	// Need to conver the map[string]interface into a resource status.
-	if update, status := runner.UpdateResourceStatus(statusMap, statusEvent); update {
+	if update, status := UpdateResourceStatus(statusMap, statusEvent); update {
 		u.Object["status"] = status
 		sdk.Update(u)
 		return nil

--- a/pkg/handler/types.go
+++ b/pkg/handler/types.go
@@ -1,18 +1,22 @@
-package runner
+package handler
+
+import (
+	"github.com/water-hole/ansible-operator/pkg/runner"
+)
 
 const (
 	host = "localhost"
 )
 
 type Status struct {
-	Ok               int       `json:"ok"`
-	Changed          int       `json:"changed"`
-	Skipped          int       `json:"skipped"`
-	Failures         int       `json:"failures"`
-	TimeOfCompletion EventTime `json:"completion"`
+	Ok               int              `json:"ok"`
+	Changed          int              `json:"changed"`
+	Skipped          int              `json:"skipped"`
+	Failures         int              `json:"failures"`
+	TimeOfCompletion runner.EventTime `json:"completion"`
 }
 
-func NewStatusFromStatusJobEvent(je *StatusJobEvent) Status {
+func NewStatusFromStatusJobEvent(je *runner.StatusJobEvent) Status {
 	// ok events.
 	o := 0
 	changed := 0
@@ -50,7 +54,7 @@ func NewStatusFromMap(sm map[string]interface{}) Status {
 	changed := 0
 	skipped := 0
 	failures := 0
-	e := EventTime{}
+	e := runner.EventTime{}
 	if v, ok := sm["changed"]; ok {
 		changed = int(v.(int64))
 	}
@@ -82,7 +86,7 @@ type ResourceStatus struct {
 	History        []Status `json:"history,omitempty"`
 }
 
-func UpdateResourceStatus(sm map[string]interface{}, je *StatusJobEvent) (bool, ResourceStatus) {
+func UpdateResourceStatus(sm map[string]interface{}, je *runner.StatusJobEvent) (bool, ResourceStatus) {
 	newStatus := NewStatusFromStatusJobEvent(je)
 	oldStatus := NewStatusFromMap(sm)
 	// Don't update the status if new status and old status are equal.


### PR DESCRIPTION
ResourceStatus represents the Status field on a CR. Everything in types.go
relates to the CR's status, and not directly to the act of running ansible.
Code in runner/types.go was *only* being used from within handler/handler.go,
which is a good indicator that the code should be moved.

A reasonable boundary is to let the runner package handle execution of ansible,
and let it return information about that run (in the form of a StatusJobEvent).
The caller (which is in the handler package) can then take that information and
do whatever is appropriate with it.