### PR TITLE
Configurable sync period

### DIFF
--- a/cmd/ansible-operator/main.go
+++ b/cmd/ansible-operator/main.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
 	"github.com/sirupsen/logrus"
+	"os"
+	"strconv"
 )
 
 func printVersion() {
@@ -29,7 +31,16 @@ func main() {
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(false))
 
-	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
+	syncPeriod := time.Duration(60 * time.Second)
+
+	if r, ok := os.LookupEnv("RESYNC_PERIOD"); ok {
+		if rp, err := strconv.Atoi(r); err == nil {
+			syncPeriod = time.Duration(rp * int(time.Second))
+		}
+	}
+
+	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{SyncPeriod: &syncPeriod})
+
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION

1. Hard code `sync period` to a same value of 1 minute, 
2. For some use cases, there might be a need for making it configurable. This PR gives ability to user to set it as an env variable, like [this](https://github.com/water-hole/etcd-ansible-operator/blob/e87e0ccd319a3f03547e672fa3f08fe0248523eb/Dockerfile#L12)