### PR TITLE
Pin the openshift and kubernetes python module versions

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@ FROM ansible/ansible-runner
 
 RUN pip install --upgrade setuptools
 RUN pip install urllib3==1.23
-RUN pip install openshift ansible-runner-http
+RUN pip install openshift==0.6.0 kubernetes==6.0.0 ansible-runner-http
 
 RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo '[defaults]' > /etc/ansible/ansible.cfg \


### PR DESCRIPTION
This lookup appears to be causing an error with openshift 0.7.2 / kubernetes 7.0.0.  I am setting a specific version until we can get to the bottom of what's wrong in the newer version.

https://github.com/openshift/ansible-service-broker/blob/master/ansible_role/defaults/main.yml#L94

```
TASK [automation-broker-apb : Set registry configuration to default registries] ***
Exception RuntimeError: RuntimeError('cannot wait on un-acquired lock',) in 
<bound method ApiClient.__del__ of <kubernetes.client.api_client.ApiClient object at 0x7f09e938f750>> ignored

Exception RuntimeError: RuntimeError('cannot wait on un-acquired lock',) in <bound method ApiClient.__del__ of <kubernetes.client.api_client.ApiClient object at 0x7f09e938f750>> ignored
ok: [localhost -> localhost]
```