### PR TITLE
Unpin python module versions

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,7 @@
 FROM ansible/ansible-runner
 
 RUN pip install --upgrade setuptools
-RUN pip install urllib3==1.23
-RUN pip install openshift==0.6.0 kubernetes==6.0.0 ansible-runner-http
+RUN pip install openshift kubernetes ansible-runner-http
 
 RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo '[defaults]' > /etc/ansible/ansible.cfg \


### PR DESCRIPTION
kubernetes 8.0.0 and openshift 0.8.0 have been released and do not appear to be hanging anymore.

The urllib3 issue also appears to have been resolved. https://github.com/ansible/ansible-runner-http/issues/1