### PR TITLE
build/Dockerfile: removing unnecessary 'yum remove ansible-runner'

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM ansible/ansible-runner
 
-RUN yum remove -y ansible ansible-runner python-idna
+RUN yum remove -y ansible python-idna
 RUN pip uninstall ansible-runner -y
 
 RUN pip install --upgrade setuptools


### PR DESCRIPTION
**Description of change:**
Removing `ansible-runner` from Dockerfile's `yum remove` line

**Motivation for change:**
`ansible-runner` is [installed by pip in the base image](https://github.com/ansible/ansible-runner/blob/master/Dockerfile#L34) so `yum remove` is unnecessary since it is be a no-op.